### PR TITLE
feat/config-types

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@ Standard SDK is an open source software package that provides you with a single 
 
 Developers commonly spent lots of time installing SDKs, reading documentation, and figuring out how to use each SDK to build integrations using APIs and to add features to their application. Instead of going through this time consuming process installing and learning many different SDKs, a developer can just install Standard SDK to build any integration their application requires. In addition to saving time, removing dependencies on all those SDKs in favor of just one can reduce your application's build size, and make it easier to onboard developers to your codebase.
 
+[![Standard SDK Introductory Demo](https://img.youtube.com/vi/hXgUag6VX30/0.jpg)](https://www.youtube.com/watch?v=hXgUag6VX30)
+
 ### How it works
 
 Standard SDK is powered by open source standardized API specifications like [OpenAPI](https://www.openapis.org/). It uses these API specifications to know how to send properly formatted web requests, RPC messages, SQL queries, etc. to the APIs you want your application to integrate with. The API specifications which Standard SDK works with or is planning to add support for include:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@comake/standard-sdk-js",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@comake/standard-sdk-js",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@comake/openapi-operation-executor": "^0.7.1",
+        "@comake/openapi-operation-executor": "^0.10.0",
         "@comake/skl-js-engine": "^0.1.0",
         "@commitlint/cli": "^17.4.1",
         "@commitlint/config-conventional": "^17.4.0",
@@ -19,8 +19,8 @@
         "@tsconfig/node16": "^1.0.3",
         "@types/jest": "^29.2.5",
         "@types/node": "^18.11.18",
-        "@typescript-eslint/eslint-plugin": "^5.3.0",
-        "@typescript-eslint/parser": "^5.4.0",
+        "@typescript-eslint/eslint-plugin": "^5.60.0",
+        "@typescript-eslint/parser": "^5.60.0",
         "axios": "^0.27.2",
         "eslint": "^8.31.0",
         "eslint-config-es": "4.1.0",
@@ -35,7 +35,7 @@
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
         "ts-toolbelt": "^9.6.0",
-        "typescript": "^4.9.4"
+        "typescript": "^5.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -700,9 +700,9 @@
       "dev": true
     },
     "node_modules/@comake/openapi-operation-executor": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@comake/openapi-operation-executor/-/openapi-operation-executor-0.7.1.tgz",
-      "integrity": "sha512-iyX/TygXYyKzZpRrUnL9RqJuYpXPMZLOZ3UBqgBGHGwg6I6wKEc8AAMfheZDuLIY0cvsMrtnpsldrk22bN9yOQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@comake/openapi-operation-executor/-/openapi-operation-executor-0.10.0.tgz",
+      "integrity": "sha512-UNOamGLgYvclw5H+PoVp/O81rLAI7W1actVqSCdhtDhEhin1YHMBqd5941pp9YE6UrRLXXHdoND5BOiozarWFg==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",
         "axios": "^0.27.2"
@@ -752,6 +752,15 @@
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
+        "axios": "^0.27.2"
+      }
+    },
+    "node_modules/@comake/skl-js-engine/node_modules/@comake/openapi-operation-executor": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@comake/openapi-operation-executor/-/openapi-operation-executor-0.7.1.tgz",
+      "integrity": "sha512-iyX/TygXYyKzZpRrUnL9RqJuYpXPMZLOZ3UBqgBGHGwg6I6wKEc8AAMfheZDuLIY0cvsMrtnpsldrk22bN9yOQ==",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.9",
         "axios": "^0.27.2"
       }
     },
@@ -887,6 +896,18 @@
         "node": ">=v14"
       }
     },
+    "node_modules/@commitlint/load/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/@commitlint/message": {
       "version": "17.4.0",
       "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.4.0.tgz",
@@ -1006,6 +1027,30 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -1979,18 +2024,20 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.3.0.tgz",
-      "integrity": "sha512-ARUEJHJrq85aaiCqez7SANeahDsJTD3AEua34EoQN9pHS6S5Bq9emcIaGGySt/4X2zSi+vF5hAH52sEen7IO7g==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.60.0.tgz",
+      "integrity": "sha512-78B+anHLF1TI8Jn/cD0Q00TBYdMgjdOn980JfAVa9yw5sop8nyTfVOQAv6LWywkOGLclDBtv5z3oxN4w7jxyNg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "5.3.0",
-        "@typescript-eslint/scope-manager": "5.3.0",
-        "debug": "^4.3.2",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.60.0",
+        "@typescript-eslint/type-utils": "5.60.0",
+        "@typescript-eslint/utils": "5.60.0",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -2010,183 +2057,16 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.0.tgz",
-      "integrity": "sha512-22Uic9oRlTsPppy5Tcwfj+QET5RWEnZ5414Prby465XxQrQFZ6nnm5KnXgnsAJefG4hEgMnaxTB3kNEyjdjj6A==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.3.0",
-        "@typescript-eslint/visitor-keys": "5.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.0.tgz",
-      "integrity": "sha512-fce5pG41/w8O6ahQEhXmMV+xuh4+GayzqEogN24EK+vECA3I6pUwKuLi5QbXO721EMitpQne5VKXofPonYlAQg==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.0.tgz",
-      "integrity": "sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.3.0",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.0.tgz",
-      "integrity": "sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.3.0",
-        "@typescript-eslint/types": "5.3.0",
-        "@typescript-eslint/typescript-estree": "5.3.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "*"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.0.tgz",
-      "integrity": "sha512-22Uic9oRlTsPppy5Tcwfj+QET5RWEnZ5414Prby465XxQrQFZ6nnm5KnXgnsAJefG4hEgMnaxTB3kNEyjdjj6A==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.3.0",
-        "@typescript-eslint/visitor-keys": "5.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/types": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.0.tgz",
-      "integrity": "sha512-fce5pG41/w8O6ahQEhXmMV+xuh4+GayzqEogN24EK+vECA3I6pUwKuLi5QbXO721EMitpQne5VKXofPonYlAQg==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.0.tgz",
-      "integrity": "sha512-FJ0nqcaUOpn/6Z4Jwbtf+o0valjBLkqc3MWkMvrhA2TvzFXtcclIM8F4MBEmYa2kgcI8EZeSAzwoSrIC8JYkug==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.3.0",
-        "@typescript-eslint/visitor-keys": "5.3.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.0.tgz",
-      "integrity": "sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.3.0",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.4.0.tgz",
-      "integrity": "sha512-JoB41EmxiYpaEsRwpZEYAJ9XQURPFer8hpkIW9GiaspVLX8oqbqNM8P4EP8HOZg96yaALiLEVWllA2E8vwsIKw==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.60.0.tgz",
+      "integrity": "sha512-jBONcBsDJ9UoTWrARkRRCgDz6wUggmH5RpQVlt7BimSwaTkTjwypGzKORXbR4/2Hqjk9hgwlon2rVQAjWNpkyQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.4.0",
-        "@typescript-eslint/types": "5.4.0",
-        "@typescript-eslint/typescript-estree": "5.4.0",
-        "debug": "^4.3.2"
+        "@typescript-eslint/scope-manager": "5.60.0",
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/typescript-estree": "5.60.0",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2204,14 +2084,14 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.4.0.tgz",
-      "integrity": "sha512-pRxFjYwoi8R+n+sibjgF9iUiAELU9ihPBtHzocyW8v8D8G8KeQvXTsW7+CBYIyTYsmhtNk50QPGLE3vrvhM5KA==",
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.60.0.tgz",
+      "integrity": "sha512-hakuzcxPwXi2ihf9WQu1BbRj1e/Pd8ZZwVTG9kfbxAMZstKz8/9OoexIwnmLzShtsdap5U/CoQGRCWlSuPbYxQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.4.0",
-        "@typescript-eslint/visitor-keys": "5.4.0"
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/visitor-keys": "5.60.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2221,31 +2101,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.4.0.tgz",
-      "integrity": "sha512-GjXNpmn+n1LvnttarX+sPD6+S7giO+9LxDIGlRl4wK3a7qMWALOHYuVSZpPTfEIklYjaWuMtfKdeByx0AcaThA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.4.0.tgz",
-      "integrity": "sha512-nhlNoBdhKuwiLMx6GrybPT3SFILm5Gij2YBdPEPFlYNFAXUJWX6QRgvi/lwVoadaQEFsizohs6aFRMqsXI2ewA==",
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.60.0.tgz",
+      "integrity": "sha512-X7NsRQddORMYRFH7FWo6sA9Y/zbJ8s1x1RIAtnlj6YprbToTiQnM6vxcMu7iYhdunmoC0rUWlca13D5DVHkK2g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.4.0",
-        "@typescript-eslint/visitor-keys": "5.4.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
+        "@typescript-eslint/typescript-estree": "5.60.0",
+        "@typescript-eslint/utils": "5.60.0",
+        "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -2255,50 +2119,19 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "peerDependencies": {
+        "eslint": "*"
+      },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.4.0.tgz",
-      "integrity": "sha512-PVbax7MeE7tdLfW5SA0fs8NGVVr+buMPrcj+CWYWPXsZCH8qZ1THufDzbXm1xrZ2b2PA1iENJ0sRq5fuUtvsJg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.4.0",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.1.tgz",
-      "integrity": "sha512-S035ueRrbxRMKvSTv9vJKIWgr86BD8s3RqoRZmsSh/s8HhIs90g6UlK8ZabUSjUZQkhVxt7nmZ63VJ9dcZhtDQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.48.1",
-        "@typescript-eslint/visitor-keys": "5.48.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.1.tgz",
-      "integrity": "sha512-xHyDLU6MSuEEdIlzrrAerCGS3T7AA/L8Hggd0RCYBi0w3JMvGYxlLlXHeg50JI9Tfg5MrtsfuNxbS/3zF1/ATg==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.60.0.tgz",
+      "integrity": "sha512-ascOuoCpNZBccFVNJRSC6rPq4EmJ2NkuoKnd6LDNyAQmdDnziAtxbCGWCbefG1CNzmDvd05zO36AmB7H8RzKPA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2309,13 +2142,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.1.tgz",
-      "integrity": "sha512-Hut+Osk5FYr+sgFh8J/FHjqX6HFcDzTlWLrFqGoK5kVUN3VBHF/QzZmAsIXCQ8T/W9nQNBTqalxi1P3LSqWnRA==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.60.0.tgz",
+      "integrity": "sha512-R43thAuwarC99SnvrBmh26tc7F6sPa2B3evkXp/8q954kYL6Ro56AwASYWtEEi+4j09GbiNAHqYwNNZuNlARGQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.48.1",
-        "@typescript-eslint/visitor-keys": "5.48.1",
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/visitor-keys": "5.60.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2336,18 +2169,18 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.1.tgz",
-      "integrity": "sha512-SmQuSrCGUOdmGMwivW14Z0Lj8dxG1mOFZ7soeJ0TQZEJcs3n5Ndgkg0A4bcMFzBELqLJ6GTHnEU+iIoaD6hFGA==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.60.0.tgz",
+      "integrity": "sha512-ba51uMqDtfLQ5+xHtwlO84vkdjrqNzOnqrnwbMHMRY8Tqeme8C2Q8Fc7LajfGR+e3/4LoYiWXUM6BpIIbHJ4hQ==",
       "dev": true,
       "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.48.1",
-        "@typescript-eslint/types": "5.48.1",
-        "@typescript-eslint/typescript-estree": "5.48.1",
+        "@typescript-eslint/scope-manager": "5.60.0",
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/typescript-estree": "5.60.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
@@ -2384,12 +2217,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.1.tgz",
-      "integrity": "sha512-Ns0XBwmfuX7ZknznfXozgnydyR8F6ev/KEGePP4i74uL3ArsKbEhJ7raeKr1JSa997DBDwol/4a0Y+At82c9dA==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.60.0.tgz",
+      "integrity": "sha512-wm9Uz71SbCyhUKgcaPRauBdTegUyY/ZWl8gLwD/i/ybJqscrrdVSFImpvUz16BLPChIeKBK5Fa9s6KDQjsjyWw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.48.1",
+        "@typescript-eslint/types": "5.60.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -4556,12 +4389,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
-    },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -6608,6 +6435,12 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
+    },
     "node_modules/node-fetch": {
       "version": "3.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
@@ -8379,15 +8212,15 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -9223,9 +9056,9 @@
       "dev": true
     },
     "@comake/openapi-operation-executor": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@comake/openapi-operation-executor/-/openapi-operation-executor-0.7.1.tgz",
-      "integrity": "sha512-iyX/TygXYyKzZpRrUnL9RqJuYpXPMZLOZ3UBqgBGHGwg6I6wKEc8AAMfheZDuLIY0cvsMrtnpsldrk22bN9yOQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@comake/openapi-operation-executor/-/openapi-operation-executor-0.10.0.tgz",
+      "integrity": "sha512-UNOamGLgYvclw5H+PoVp/O81rLAI7W1actVqSCdhtDhEhin1YHMBqd5941pp9YE6UrRLXXHdoND5BOiozarWFg==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",
         "axios": "^0.27.2"
@@ -9272,6 +9105,17 @@
         "sparql-http-client": "^2.4.1",
         "sparqljs": "^3.6.2",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@comake/openapi-operation-executor": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/@comake/openapi-operation-executor/-/openapi-operation-executor-0.7.1.tgz",
+          "integrity": "sha512-iyX/TygXYyKzZpRrUnL9RqJuYpXPMZLOZ3UBqgBGHGwg6I6wKEc8AAMfheZDuLIY0cvsMrtnpsldrk22bN9yOQ==",
+          "requires": {
+            "@apidevtools/json-schema-ref-parser": "^9.0.9",
+            "axios": "^0.27.2"
+          }
+        }
       }
     },
     "@commitlint/cli": {
@@ -9374,6 +9218,13 @@
         "resolve-from": "^5.0.0",
         "ts-node": "^10.8.1",
         "typescript": "^4.6.4"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+        }
       }
     },
     "@commitlint/message": {
@@ -9466,6 +9317,21 @@
         "ky": "^0.25.1",
         "ky-universal": "^0.8.2"
       }
+    },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "dev": true
     },
     "@eslint/eslintrc": {
       "version": "1.4.1",
@@ -10291,201 +10157,71 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.3.0.tgz",
-      "integrity": "sha512-ARUEJHJrq85aaiCqez7SANeahDsJTD3AEua34EoQN9pHS6S5Bq9emcIaGGySt/4X2zSi+vF5hAH52sEen7IO7g==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.60.0.tgz",
+      "integrity": "sha512-78B+anHLF1TI8Jn/cD0Q00TBYdMgjdOn980JfAVa9yw5sop8nyTfVOQAv6LWywkOGLclDBtv5z3oxN4w7jxyNg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "5.3.0",
-        "@typescript-eslint/scope-manager": "5.3.0",
-        "debug": "^4.3.2",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.60.0",
+        "@typescript-eslint/type-utils": "5.60.0",
+        "@typescript-eslint/utils": "5.60.0",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.0.tgz",
-          "integrity": "sha512-22Uic9oRlTsPppy5Tcwfj+QET5RWEnZ5414Prby465XxQrQFZ6nnm5KnXgnsAJefG4hEgMnaxTB3kNEyjdjj6A==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.3.0",
-            "@typescript-eslint/visitor-keys": "5.3.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.0.tgz",
-          "integrity": "sha512-fce5pG41/w8O6ahQEhXmMV+xuh4+GayzqEogN24EK+vECA3I6pUwKuLi5QbXO721EMitpQne5VKXofPonYlAQg==",
-          "dev": true
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.0.tgz",
-          "integrity": "sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.3.0",
-            "eslint-visitor-keys": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@typescript-eslint/experimental-utils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.0.tgz",
-      "integrity": "sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.3.0",
-        "@typescript-eslint/types": "5.3.0",
-        "@typescript-eslint/typescript-estree": "5.3.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.0.tgz",
-          "integrity": "sha512-22Uic9oRlTsPppy5Tcwfj+QET5RWEnZ5414Prby465XxQrQFZ6nnm5KnXgnsAJefG4hEgMnaxTB3kNEyjdjj6A==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.3.0",
-            "@typescript-eslint/visitor-keys": "5.3.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.0.tgz",
-          "integrity": "sha512-fce5pG41/w8O6ahQEhXmMV+xuh4+GayzqEogN24EK+vECA3I6pUwKuLi5QbXO721EMitpQne5VKXofPonYlAQg==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.0.tgz",
-          "integrity": "sha512-FJ0nqcaUOpn/6Z4Jwbtf+o0valjBLkqc3MWkMvrhA2TvzFXtcclIM8F4MBEmYa2kgcI8EZeSAzwoSrIC8JYkug==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.3.0",
-            "@typescript-eslint/visitor-keys": "5.3.0",
-            "debug": "^4.3.2",
-            "globby": "^11.0.4",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.0.tgz",
-          "integrity": "sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.3.0",
-            "eslint-visitor-keys": "^3.0.0"
-          }
-        },
-        "eslint-scope": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-          "dev": true
-        }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.4.0.tgz",
-      "integrity": "sha512-JoB41EmxiYpaEsRwpZEYAJ9XQURPFer8hpkIW9GiaspVLX8oqbqNM8P4EP8HOZg96yaALiLEVWllA2E8vwsIKw==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.60.0.tgz",
+      "integrity": "sha512-jBONcBsDJ9UoTWrARkRRCgDz6wUggmH5RpQVlt7BimSwaTkTjwypGzKORXbR4/2Hqjk9hgwlon2rVQAjWNpkyQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.4.0",
-        "@typescript-eslint/types": "5.4.0",
-        "@typescript-eslint/typescript-estree": "5.4.0",
-        "debug": "^4.3.2"
-      },
-      "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.4.0.tgz",
-          "integrity": "sha512-pRxFjYwoi8R+n+sibjgF9iUiAELU9ihPBtHzocyW8v8D8G8KeQvXTsW7+CBYIyTYsmhtNk50QPGLE3vrvhM5KA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.4.0",
-            "@typescript-eslint/visitor-keys": "5.4.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.4.0.tgz",
-          "integrity": "sha512-GjXNpmn+n1LvnttarX+sPD6+S7giO+9LxDIGlRl4wK3a7qMWALOHYuVSZpPTfEIklYjaWuMtfKdeByx0AcaThA==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.4.0.tgz",
-          "integrity": "sha512-nhlNoBdhKuwiLMx6GrybPT3SFILm5Gij2YBdPEPFlYNFAXUJWX6QRgvi/lwVoadaQEFsizohs6aFRMqsXI2ewA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.4.0",
-            "@typescript-eslint/visitor-keys": "5.4.0",
-            "debug": "^4.3.2",
-            "globby": "^11.0.4",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.4.0.tgz",
-          "integrity": "sha512-PVbax7MeE7tdLfW5SA0fs8NGVVr+buMPrcj+CWYWPXsZCH8qZ1THufDzbXm1xrZ2b2PA1iENJ0sRq5fuUtvsJg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.4.0",
-            "eslint-visitor-keys": "^3.0.0"
-          }
-        }
+        "@typescript-eslint/scope-manager": "5.60.0",
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/typescript-estree": "5.60.0",
+        "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.1.tgz",
-      "integrity": "sha512-S035ueRrbxRMKvSTv9vJKIWgr86BD8s3RqoRZmsSh/s8HhIs90g6UlK8ZabUSjUZQkhVxt7nmZ63VJ9dcZhtDQ==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.60.0.tgz",
+      "integrity": "sha512-hakuzcxPwXi2ihf9WQu1BbRj1e/Pd8ZZwVTG9kfbxAMZstKz8/9OoexIwnmLzShtsdap5U/CoQGRCWlSuPbYxQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.48.1",
-        "@typescript-eslint/visitor-keys": "5.48.1"
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/visitor-keys": "5.60.0"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.60.0.tgz",
+      "integrity": "sha512-X7NsRQddORMYRFH7FWo6sA9Y/zbJ8s1x1RIAtnlj6YprbToTiQnM6vxcMu7iYhdunmoC0rUWlca13D5DVHkK2g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "5.60.0",
+        "@typescript-eslint/utils": "5.60.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.1.tgz",
-      "integrity": "sha512-xHyDLU6MSuEEdIlzrrAerCGS3T7AA/L8Hggd0RCYBi0w3JMvGYxlLlXHeg50JI9Tfg5MrtsfuNxbS/3zF1/ATg==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.60.0.tgz",
+      "integrity": "sha512-ascOuoCpNZBccFVNJRSC6rPq4EmJ2NkuoKnd6LDNyAQmdDnziAtxbCGWCbefG1CNzmDvd05zO36AmB7H8RzKPA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.1.tgz",
-      "integrity": "sha512-Hut+Osk5FYr+sgFh8J/FHjqX6HFcDzTlWLrFqGoK5kVUN3VBHF/QzZmAsIXCQ8T/W9nQNBTqalxi1P3LSqWnRA==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.60.0.tgz",
+      "integrity": "sha512-R43thAuwarC99SnvrBmh26tc7F6sPa2B3evkXp/8q954kYL6Ro56AwASYWtEEi+4j09GbiNAHqYwNNZuNlARGQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.48.1",
-        "@typescript-eslint/visitor-keys": "5.48.1",
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/visitor-keys": "5.60.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -10494,18 +10230,18 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.1.tgz",
-      "integrity": "sha512-SmQuSrCGUOdmGMwivW14Z0Lj8dxG1mOFZ7soeJ0TQZEJcs3n5Ndgkg0A4bcMFzBELqLJ6GTHnEU+iIoaD6hFGA==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.60.0.tgz",
+      "integrity": "sha512-ba51uMqDtfLQ5+xHtwlO84vkdjrqNzOnqrnwbMHMRY8Tqeme8C2Q8Fc7LajfGR+e3/4LoYiWXUM6BpIIbHJ4hQ==",
       "dev": true,
       "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.48.1",
-        "@typescript-eslint/types": "5.48.1",
-        "@typescript-eslint/typescript-estree": "5.48.1",
+        "@typescript-eslint/scope-manager": "5.60.0",
+        "@typescript-eslint/types": "5.60.0",
+        "@typescript-eslint/typescript-estree": "5.60.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       },
       "dependencies": {
@@ -10528,12 +10264,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.1.tgz",
-      "integrity": "sha512-Ns0XBwmfuX7ZknznfXozgnydyR8F6ev/KEGePP4i74uL3ArsKbEhJ7raeKr1JSa997DBDwol/4a0Y+At82c9dA==",
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.60.0.tgz",
+      "integrity": "sha512-wm9Uz71SbCyhUKgcaPRauBdTegUyY/ZWl8gLwD/i/ybJqscrrdVSFImpvUz16BLPChIeKBK5Fa9s6KDQjsjyWw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.48.1",
+        "@typescript-eslint/types": "5.60.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -12092,12 +11828,6 @@
         "functions-have-names": "^1.2.2"
       }
     },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true
-    },
     "functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -13579,6 +13309,12 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
+    },
     "node-fetch": {
       "version": "3.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
@@ -14888,9 +14624,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "dist"
   ],
   "dependencies": {
-    "@comake/openapi-operation-executor": "^0.7.1",
+    "@comake/openapi-operation-executor": "^0.10.0",
     "@comake/skl-js-engine": "^0.1.0",
     "@commitlint/cli": "^17.4.1",
     "@commitlint/config-conventional": "^17.4.0",
@@ -66,8 +66,8 @@
     "@tsconfig/node16": "^1.0.3",
     "@types/jest": "^29.2.5",
     "@types/node": "^18.11.18",
-    "@typescript-eslint/eslint-plugin": "^5.3.0",
-    "@typescript-eslint/parser": "^5.4.0",
+    "@typescript-eslint/eslint-plugin": "^5.60.0",
+    "@typescript-eslint/parser": "^5.60.0",
     "axios": "^0.27.2",
     "eslint": "^8.31.0",
     "eslint-config-es": "4.1.0",
@@ -82,6 +82,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "ts-toolbelt": "^9.6.0",
-    "typescript": "^4.9.4"
+    "typescript": "^5.1.0"
   }
 }

--- a/src/ApiOperationNamespace.ts
+++ b/src/ApiOperationNamespace.ts
@@ -1,6 +1,8 @@
-import type { ApiSpecType } from './ApiSpecOptions';
+import type { ApiSpecOptions } from './ApiSpecOptions';
 import type { OpenApiOperationNamespace } from './openapi-types/OpenApiOperationNamespace';
 
-export type ApiOperationNamespace<T extends ApiSpecType, TSpec> = {
-  openapi: OpenApiOperationNamespace<TSpec>;
-}[T];
+export type ApiOperationNamespace<
+  T extends ApiSpecOptions
+> = T['type'] extends 'openapi'
+  ? OpenApiOperationNamespace<T['value'], T['defaultConfiguration']>
+  : never;

--- a/src/OperationHandler.ts
+++ b/src/OperationHandler.ts
@@ -1,5 +1,1 @@
-export type OperationHandler = (
-  args?: any,
-  configuration?: any,
-  options?: any
-) => Promise<any>;
+export type OperationHandler = (args: any, configuration: any, options?: any) => Promise<any>;

--- a/src/openapi-types/OpenApiArgTypes.ts
+++ b/src/openapi-types/OpenApiArgTypes.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import type {
   OpenApi,
   Operation,
@@ -120,4 +121,4 @@ export type OpenApiArgTypes<
   TSpec extends OpenApi,
   TOperation extends string = string,
   TParams = ArgsOfOpenApiOperation<TSpec, TOperation>
-> = [TParams] extends [never] ? any : TParams;
+> = [TParams] extends [never] ? undefined : TParams;

--- a/src/openapi-types/OpenApiConfigurationTypes.ts
+++ b/src/openapi-types/OpenApiConfigurationTypes.ts
@@ -1,0 +1,102 @@
+import type {
+  OpenApi,
+  Operation,
+  PathItem,
+  SecurityRequirement,
+  OpenApiClientConfiguration,
+} from '@comake/openapi-operation-executor';
+import type { Merged } from '../type-utils/Merged';
+import type { UnionToIntersection } from '../type-utils/UnionToIntersection';
+import type { OpenApiOperationType } from './OpenApiOperationType';
+
+type DistributiveOptional<T, TK extends string> = T extends any
+  ? OpenApiClientConfiguration & Omit<T, TK>
+  : never;
+
+type AnyFunction = (...args: any[]) => any;
+
+type ExpandRecursively<T> = T extends object
+  ? T extends Promise<any>
+    ? T
+    : T extends AnyFunction
+      ? T
+      : T extends infer O ? {[K in keyof O]: ExpandRecursively<O[K]> } : never
+  : T;
+
+type UnionOfRequired<T, TH = Merged<UnionToIntersection<T>>> =
+  T extends any
+    ? keyof T extends 'bearerToken' | 'username' | 'password' | 'accessToken'
+      ? never
+      : TH & Required<T>
+    : never;
+
+type OpenApiSecurityRequirementToType<
+  T extends SecurityRequirement,
+  TSecurityTypes extends Record<string, OpenApiClientConfiguration>,
+  TInter = {[K in keyof T & string]: TSecurityTypes[K] }[keyof T & string],
+> = keyof TInter extends 'apiKey'
+  ? UnionOfRequired<TInter>
+  : TInter;
+
+type OpenApiSecurityRequirementToTypeWithDefaults<
+  T extends SecurityRequirement,
+  TSecurityTypes extends Record<string, OpenApiClientConfiguration>,
+  TDefaultConfig extends string | undefined,
+  TConfig = OpenApiSecurityRequirementToType<T, TSecurityTypes>,
+> = TDefaultConfig extends string
+  ? DistributiveOptional<TConfig, TDefaultConfig>
+  : OpenApiClientConfiguration & TConfig;
+
+type OpenApiSecurityRequirementToTypes<
+  T extends readonly SecurityRequirement[],
+  TSecurityTypes extends Record<string, OpenApiClientConfiguration>,
+  TDefaultConfig extends string | undefined,
+> = {[K in keyof T]: OpenApiSecurityRequirementToTypeWithDefaults<T[K], TSecurityTypes, TDefaultConfig> }[number];
+
+type ConfigurationOfOperationInPathItemIfDefined<
+  T extends PathItem,
+  TOperation extends string,
+  TSpec extends OpenApi,
+  TDefaultConfig extends string | undefined,
+  TSecurityTypes extends Record<string, OpenApiClientConfiguration>,
+  TOperationObject = Extract<T[keyof T & OpenApiOperationType], { operationId: TOperation }>
+> = [TOperationObject] extends [never]
+  ? never
+  : TOperationObject extends Operation
+    ? TOperationObject['security'] extends readonly SecurityRequirement[]
+      ? OpenApiSecurityRequirementToTypes<TOperationObject['security'], TSecurityTypes, TDefaultConfig>
+      : TSpec['security'] extends readonly SecurityRequirement[]
+        ? OpenApiSecurityRequirementToTypes<TSpec['security'], TSecurityTypes, TDefaultConfig>
+        : never
+    : never;
+
+type ConfigurationOfOpenApiOperation<
+  T extends OpenApi,
+  TOperation extends string,
+  TDefaultConfig extends string | undefined,
+  TSecurityTypes extends Record<string, OpenApiClientConfiguration>
+> = {
+  [key in keyof T['paths']]: ConfigurationOfOperationInPathItemIfDefined<
+    T['paths'][key],
+    TOperation,
+    T,
+    TDefaultConfig,
+    TSecurityTypes
+  >
+}[keyof T['paths']];
+
+type UndefinedOrStringKeyOf<T extends Record<string, any> | undefined | unknown> =
+  T extends object
+    ? keyof T & string
+    : undefined;
+
+export type OpenApiClientConfigurationTypes<
+  TSpec extends OpenApi,
+  TOperation extends string,
+  TSecurityTypes extends Record<string, OpenApiClientConfiguration>,
+  TDefaultConfig extends OpenApiClientConfiguration | undefined = undefined,
+  TDefaultConfigKeys extends string | undefined = UndefinedOrStringKeyOf<TDefaultConfig>,
+  TConfig = ExpandRecursively<
+    ConfigurationOfOpenApiOperation<TSpec, TOperation, TDefaultConfigKeys, TSecurityTypes>
+  >
+> = [TConfig] extends [never] ? undefined : TConfig;

--- a/src/openapi-types/OpenApiOperationNamespace.ts
+++ b/src/openapi-types/OpenApiOperationNamespace.ts
@@ -1,7 +1,46 @@
-import type { OpenApi, OpenApiClientConfiguration, Operation, PathItem } from '@comake/openapi-operation-executor';
+import type {
+  OpenApi,
+  OpenApiClientConfiguration,
+  Operation,
+  PathItem,
+  Components,
+  SecurityScheme,
+  APIKeySecurityScheme,
+  HTTPSecurityScheme,
+  OAuth2SecurityScheme,
+} from '@comake/openapi-operation-executor';
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 import type { OpenApiArgTypes } from './OpenApiArgTypes';
+import type { OpenApiClientConfigurationTypes } from './OpenApiConfigurationTypes';
 import type { OpenApiOperationType } from './OpenApiOperationType';
+
+type OpenApiSecuritySchemeToType<T extends SecurityScheme> =
+  T extends APIKeySecurityScheme
+    ? {[K in T['name']]?: OpenApiClientConfiguration['apiKey'] } |
+    { apiKey?: OpenApiClientConfiguration['apiKey'] }
+    : T extends OAuth2SecurityScheme
+      ? { accessToken: OpenApiClientConfiguration['accessToken'] }
+      : T extends HTTPSecurityScheme
+        ? T['scheme'] extends 'basic'
+          ? {
+            username: OpenApiClientConfiguration['username'];
+            password: OpenApiClientConfiguration['password'];
+          }
+          : T['scheme'] extends 'bearer'
+            ? { bearerToken: OpenApiClientConfiguration['bearerToken'] }
+            : never
+        : never;
+
+export type OpenApiSecuritySchemesToTypes<
+  TSpec extends OpenApi
+> = TSpec['components'] extends Components
+  ? TSpec['components']['securitySchemes'] extends Record<string, SecurityScheme>
+    ? {
+      [K in keyof TSpec['components']['securitySchemes']]:
+      OpenApiSecuritySchemeToType<TSpec['components']['securitySchemes'][K]>;
+    }
+    : Record<string, never>
+  : Record<string, never>;
 
 type OperationsOfPathItem<T extends PathItem> = {
   [operationType in keyof T & OpenApiOperationType]: T[operationType] extends Operation
@@ -13,16 +52,46 @@ type OperationIdsOfOpenApi<T extends OpenApi> = {
   [path in keyof T['paths']]: Exclude<OperationsOfPathItem<T['paths'][path]>, undefined>
 }[keyof T['paths']];
 
-type OpenApiOperationInterface<T extends OpenApi> = {
-  [operation in OperationIdsOfOpenApi<T>]: (
-    args?: OpenApiArgTypes<T, operation>,
-    configuration?: OpenApiClientConfiguration,
-    options?: AxiosRequestConfig
-  ) => Promise<AxiosResponse>
+type OpenApiOperationInterfaceForOperation<
+  T extends string,
+  TSpec extends OpenApi,
+  TDefaultConfig extends OpenApiClientConfiguration | undefined,
+  TSecurityTypes extends Record<string, OpenApiClientConfiguration> = OpenApiSecuritySchemesToTypes<TSpec>,
+  TArgs = OpenApiArgTypes<TSpec, T>,
+  TConfig = OpenApiClientConfigurationTypes<TSpec, T, TSecurityTypes, TDefaultConfig>
+> = TArgs extends undefined
+  ? [TConfig] extends undefined
+    // eslint-disable-next-line max-len
+    ? (args?: Record<string, any>, configuration?: OpenApiClientConfiguration, options?: AxiosRequestConfig) => Promise<AxiosResponse>
+    : [TConfig] extends [undefined]
+      // eslint-disable-next-line max-len
+      ? (args: Record<string, any>, configuration?: OpenApiClientConfiguration, options?: AxiosRequestConfig) => Promise<AxiosResponse>
+      : (args: Record<string, any>, configuration: TConfig, options?: AxiosRequestConfig) => Promise<AxiosResponse>
+  : [TConfig] extends undefined
+    ? (args: TArgs, configuration?: OpenApiClientConfiguration, options?: AxiosRequestConfig) => Promise<AxiosResponse>
+    : [TConfig] extends [undefined]
+      // eslint-disable-next-line max-len
+      ? (args: TArgs, configuration?: OpenApiClientConfiguration, options?: AxiosRequestConfig) => Promise<AxiosResponse>
+      : (args: TArgs, configuration: TConfig, options?: AxiosRequestConfig) => Promise<AxiosResponse>;
+
+type OpenApiOperationInterface<
+  T extends OpenApi,
+  TDefaultConfig extends OpenApiClientConfiguration | undefined,
+  TSecurityTypes extends Record<string, OpenApiClientConfiguration> = OpenApiSecuritySchemesToTypes<T>,
+> = {
+  [operation in OperationIdsOfOpenApi<T>]: OpenApiOperationInterfaceForOperation<
+    operation,
+    T,
+    TDefaultConfig,
+    TSecurityTypes
+  >
 };
 
-export type OpenApiOperationNamespace<T> = T extends OpenApi
-  ? OpenApiOperationInterface<T>
+export type OpenApiOperationNamespace<
+  T extends string | OpenApi,
+  TDefaultConfig extends OpenApiClientConfiguration | undefined,
+> = T extends OpenApi
+  ? OpenApiOperationInterface<T, TDefaultConfig>
   : Record<string, (
     args?: any,
     configuration?: OpenApiClientConfiguration,

--- a/src/openapi-types/OpenApiSpecOptions.ts
+++ b/src/openapi-types/OpenApiSpecOptions.ts
@@ -1,4 +1,4 @@
-import type { OpenApi } from '@comake/openapi-operation-executor';
+import type { OpenApi, OpenApiClientConfiguration } from '@comake/openapi-operation-executor';
 import type { BaseApiSpecOptions } from '../BaseApiSpecOptions';
 
 export interface OpenApiSpecOptions extends BaseApiSpecOptions {
@@ -11,4 +11,8 @@ export interface OpenApiSpecOptions extends BaseApiSpecOptions {
   * Either an OpenApi conformant JSON object, or a stringified representation of one.
   */
   readonly value: string | OpenApi;
+  /**
+  * Default configuration supplied to every operation of this API.
+  */
+  readonly defaultConfiguration?: OpenApiClientConfiguration;
 }

--- a/test/integration/OperationExecution.test.ts
+++ b/test/integration/OperationExecution.test.ts
@@ -14,7 +14,7 @@ describeIf('docker', 'Operation execution', (): void => {
     });
     const response = await ssdk.ticketmaster.SearchEvents(
       { dmaId: '220' },
-      { apiKey: process.env.TICKETMASTER_APIKEY },
+      { apiKey: process.env.TICKETMASTER_APIKEY! },
     );
     expect(response.data).toBeInstanceOf(Object);
     expect(response.data._embedded.events).toBeInstanceOf(Array);

--- a/test/types/OpenApiArgTypes.type.test.ts
+++ b/test/types/OpenApiArgTypes.type.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable no-unused-expressions */
 import type { A } from 'ts-toolbelt';
 import type { OpenApiArgTypes } from '../../src/openapi-types/OpenApiArgTypes';

--- a/test/types/OpenApiConfigurationTypes.type.test.ts
+++ b/test/types/OpenApiConfigurationTypes.type.test.ts
@@ -1,0 +1,365 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable no-unused-expressions */
+import type { A, O } from 'ts-toolbelt';
+import type { OpenApiClientConfigurationTypes } from '../../src/openapi-types/OpenApiConfigurationTypes';
+import type { OpenApiSecuritySchemesToTypes } from '../../src/openapi-types/OpenApiOperationNamespace';
+
+const openApi = {
+  openapi: '3.1.0',
+  info: { title: 'Example', version: '1.0.0' },
+  paths: {},
+  components: {
+    securitySchemes: {
+      bearer: {
+        type: 'http',
+        scheme: 'bearer',
+      },
+      basic: {
+        type: 'http',
+        scheme: 'basic',
+      },
+      apikey: {
+        type: 'apiKey',
+        name: 'key',
+        in: 'query',
+      },
+      oauth: {
+        type: 'oauth2',
+        flows: {},
+      },
+    },
+  },
+} as const;
+
+const operation = {
+  operationId: 'GetOperation',
+  responses: {},
+} as const;
+
+const openApiWithBearerSecurity = {
+  ...openApi,
+  paths: {
+    '/path/to/operation': {
+      get: {
+        ...operation,
+        security: [{ bearer: []}],
+      },
+    },
+  },
+} as const;
+
+const openApiWithBasicSecurity = {
+  ...openApi,
+  paths: {
+    '/path/to/operation': {
+      get: {
+        ...operation,
+        security: [{ basic: []}],
+      },
+    },
+  },
+} as const;
+
+const openApiWithApiKeySecurity = {
+  ...openApi,
+  paths: {
+    '/path/to/operation': {
+      get: {
+        ...operation,
+        security: [{ apikey: []}],
+      },
+    },
+  },
+} as const;
+
+const openApiWithOauthSecurity = {
+  ...openApi,
+  paths: {
+    '/path/to/operation': {
+      get: {
+        ...operation,
+        security: [{ oauth: []}],
+      },
+    },
+  },
+} as const;
+
+const openApiWithMultiSecurity = {
+  ...openApi,
+  paths: {
+    '/path/to/operation': {
+      get: {
+        ...operation,
+        security: [{
+          apikey: [],
+          bearer: [],
+        }],
+      },
+    },
+  },
+} as const;
+
+type SecurityTypes = OpenApiSecuritySchemesToTypes<typeof openApi>;
+
+type Config1 = OpenApiClientConfigurationTypes<
+  typeof openApiWithBearerSecurity,
+  'GetOperation',
+  SecurityTypes
+>;
+type ExpectedConfig1 = {
+  bearerToken: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  [key: string]: undefined
+  | string
+  | Promise<string>
+  | ((name: string) => string)
+  | ((name: string) => Promise<string>);
+  apiKey?: string
+  | Promise<string>
+  | ((name: string) => string)
+  | ((name: string) => Promise<string>);
+  username?: string;
+  password?: string;
+  accessToken?:
+  | string
+  | Promise<string>
+  | ((name?: string, scopes?: readonly string[]) => string)
+  | ((name?: string, scopes?: readonly string[]) => Promise<string>);
+  basePath?: string;
+  baseOptions?: any;
+};
+const assertConfigFromBearerSecurityRequirement: A.Equals<Config1, ExpectedConfig1> = 1;
+assertConfigFromBearerSecurityRequirement;
+
+type Config2 = OpenApiClientConfigurationTypes<
+  typeof openApiWithBasicSecurity,
+  'GetOperation',
+  SecurityTypes
+>;
+type ExpectedConfig2 = {
+  username: string | undefined;
+  password: string | undefined;
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  [key: string]: undefined
+  | string
+  | Promise<string>
+  | ((name: string) => string)
+  | ((name: string) => Promise<string>);
+  apiKey?: string
+  | Promise<string>
+  | ((name: string) => string)
+  | ((name: string) => Promise<string>);
+  accessToken?: string | Promise<string>
+  | ((name?: string, scopes?: readonly string[]) => string)
+  | ((name?: string, scopes?: readonly string[]) => Promise<string>);
+  basePath?: string;
+  baseOptions?: any;
+};
+const assertConfigFromBasicSecurityRequirement: A.Equals<Config2, ExpectedConfig2> = 1;
+assertConfigFromBasicSecurityRequirement;
+
+type Config3 = OpenApiClientConfigurationTypes<
+  typeof openApiWithApiKeySecurity,
+  'GetOperation',
+  SecurityTypes
+>;
+type ExpectedConfig3 = {
+  [x: string]: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  // eslint-disable-next-line max-len
+  apiKey: (string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined) & (string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>));
+  username?: string | undefined;
+  password?: string | undefined;
+  // eslint-disable-next-line max-len
+  accessToken?: string | Promise<string> | ((name?: string | undefined, scopes?: readonly string[] | undefined) => string) | ((name?: string | undefined, scopes?: readonly string[] | undefined) => Promise<string>) | undefined;
+  basePath?: string | undefined;
+  baseOptions?: any;
+} | {
+  [x: string]: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  username?: string | undefined;
+  password?: string | undefined;
+  // eslint-disable-next-line max-len
+  accessToken?: string | Promise<string> | ((name?: string | undefined, scopes?: readonly string[] | undefined) => string) | ((name?: string | undefined, scopes?: readonly string[] | undefined) => Promise<string>) | undefined;
+  basePath?: string | undefined;
+  baseOptions?: any;
+  key: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
+};
+const assertConfigFromApiKeySecurityRequirement: keyof O.Diff<Config3, ExpectedConfig3> extends never ? 1 : 0 = 1;
+assertConfigFromApiKeySecurityRequirement;
+
+type Config4 = OpenApiClientConfigurationTypes<
+  typeof openApiWithOauthSecurity,
+  'GetOperation',
+  SecurityTypes
+>;
+type ExpectedConfig4 = {
+  [x: string]: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  username?: string | undefined;
+  password?: string | undefined;
+  // eslint-disable-next-line max-len
+  accessToken: string | Promise<string> | ((name?: string | undefined, scopes?: readonly string[] | undefined) => string) | ((name?: string | undefined, scopes?: readonly string[] | undefined) => Promise<string>) | undefined;
+  basePath?: string | undefined;
+  baseOptions?: any;
+};
+const assertConfigFromOauthSecurityRequirement: A.Equals<Config4, ExpectedConfig4> = 1;
+assertConfigFromOauthSecurityRequirement;
+
+type Config5 = OpenApiClientConfigurationTypes<
+  typeof openApiWithMultiSecurity,
+  'GetOperation',
+  SecurityTypes
+>;
+type ExpectedConfig5 = {
+  [x: string]: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  // eslint-disable-next-line max-len
+  apiKey: (string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined) & (string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>));
+  username?: string | undefined;
+  password?: string | undefined;
+  // eslint-disable-next-line max-len
+  accessToken?: string | Promise<string> | ((name?: string | undefined, scopes?: readonly string[] | undefined) => string) | ((name?: string | undefined, scopes?: readonly string[] | undefined) => Promise<string>) | undefined;
+  basePath?: string | undefined;
+  baseOptions?: any;
+} | {
+  [x: string]: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  username?: string | undefined;
+  password?: string | undefined;
+  // eslint-disable-next-line max-len
+  accessToken?: string | Promise<string> | ((name?: string | undefined, scopes?: readonly string[] | undefined) => string) | ((name?: string | undefined, scopes?: readonly string[] | undefined) => Promise<string>) | undefined;
+  basePath?: string | undefined;
+  baseOptions?: any;
+  key: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
+};
+const assertConfigFromMultiSecurityRequirement: keyof O.Diff<Config5, ExpectedConfig5> extends never ? 1 : 0 = 1;
+assertConfigFromMultiSecurityRequirement;
+
+type Config6 = OpenApiClientConfigurationTypes<
+  typeof openApiWithBearerSecurity,
+  'GetOperation',
+  SecurityTypes,
+  { bearerToken: string }
+>;
+type ExpectedConfig6 = {
+  [x: string]: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  username?: string | undefined;
+  password?: string | undefined;
+  // eslint-disable-next-line max-len
+  accessToken?: string | Promise<string> | ((name?: string | undefined, scopes?: readonly string[] | undefined) => string) | ((name?: string | undefined, scopes?: readonly string[] | undefined) => Promise<string>) | undefined;
+  basePath?: string | undefined;
+  baseOptions?: any;
+};
+const assertConfigFromBearerSecurityRequirementWithDefault: A.Equals<Config6, ExpectedConfig6> = 1;
+assertConfigFromBearerSecurityRequirementWithDefault;
+
+type Config7 = OpenApiClientConfigurationTypes<
+  typeof openApiWithBasicSecurity,
+  'GetOperation',
+  SecurityTypes,
+  { username: string }
+>;
+type ExpectedConfig7 = {
+  [x: string]: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  username?: string | undefined;
+  password: string | undefined;
+  // eslint-disable-next-line max-len
+  accessToken?: string | Promise<string> | ((name?: string | undefined, scopes?: readonly string[] | undefined) => string) | ((name?: string | undefined, scopes?: readonly string[] | undefined) => Promise<string>) | undefined;
+  basePath?: string | undefined;
+  baseOptions?: any;
+};
+const assertConfigFromBasicSecurityRequirementWithDefault: A.Equals<Config7, ExpectedConfig7> = 1;
+assertConfigFromBasicSecurityRequirementWithDefault;
+
+type Config8 = OpenApiClientConfigurationTypes<
+  typeof openApiWithApiKeySecurity,
+  'GetOperation',
+  SecurityTypes,
+  { key: 'abc123' }
+>;
+type ExpectedConfig8 = {
+  [x: string]: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  // eslint-disable-next-line max-len
+  apiKey: (string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined) & ((string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined) & (string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>)));
+  username?: string | undefined;
+  password?: string | undefined;
+  // eslint-disable-next-line max-len
+  accessToken?: string | Promise<string> | ((name?: string | undefined, scopes?: readonly string[] | undefined) => string) | ((name?: string | undefined, scopes?: readonly string[] | undefined) => Promise<string>) | undefined;
+  basePath?: string | undefined;
+  baseOptions?: any;
+} | {
+  [x: string]: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  // eslint-disable-next-line max-len
+  apiKey?: (string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined) & ((string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined) & (string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>)));
+  username?: string | undefined;
+  password?: string | undefined;
+  // eslint-disable-next-line max-len
+  accessToken?: string | Promise<string> | ((name?: string | undefined, scopes?: readonly string[] | undefined) => string) | ((name?: string | undefined, scopes?: readonly string[] | undefined) => Promise<string>) | undefined;
+  basePath?: string | undefined;
+  baseOptions?: any;
+  key: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
+};
+// eslint-disable-next-line max-len
+const assertConfigFromApiKeySecurityRequirementWithDefault: keyof O.Diff<Config8, ExpectedConfig8> extends never ? 1 : 0 = 1;
+assertConfigFromApiKeySecurityRequirementWithDefault;
+
+type Config9 = OpenApiClientConfigurationTypes<
+  typeof openApiWithOauthSecurity,
+  'GetOperation',
+  SecurityTypes,
+  { accessToken: string }
+>;
+type ExpectedConfig9 = {
+  [x: string]: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  username?: string | undefined;
+  password?: string | undefined;
+  // eslint-disable-next-line max-len
+  accessToken?: string | Promise<string> | ((name?: string | undefined, scopes?: readonly string[] | undefined) => string) | ((name?: string | undefined, scopes?: readonly string[] | undefined) => Promise<string>) | undefined;
+  basePath?: string | undefined;
+  baseOptions?: any;
+};
+const assertConfigFromOauthSecurityRequirementWithDefault: A.Equals<Config9, ExpectedConfig9> = 1;
+assertConfigFromOauthSecurityRequirementWithDefault;
+
+type Config10 = OpenApiClientConfigurationTypes<
+  typeof openApiWithMultiSecurity,
+  'GetOperation',
+  SecurityTypes,
+  { bearerToken: string }
+>;
+type ExpectedConfig10 = {
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  apiKey: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
+  [x: string]: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  username?: string | undefined;
+  password?: string | undefined;
+  // eslint-disable-next-line max-len
+  accessToken?: string | Promise<string> | ((name?: string | undefined, scopes?: readonly string[] | undefined) => string) | ((name?: string | undefined, scopes?: readonly string[] | undefined) => Promise<string>) | undefined;
+  basePath?: string | undefined;
+  baseOptions?: any;
+} | {
+  bearerToken?: string | Promise<string> | (() => string) | (() => Promise<string>) | undefined;
+  apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  key: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
+  [x: string]: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>) | undefined;
+  username?: string | undefined;
+  password?: string | undefined;
+  // eslint-disable-next-line max-len
+  accessToken?: string | Promise<string> | ((name?: string | undefined, scopes?: readonly string[] | undefined) => string) | ((name?: string | undefined, scopes?: readonly string[] | undefined) => Promise<string>) | undefined;
+  basePath?: string | undefined;
+  baseOptions?: any;
+};
+// eslint-disable-next-line max-len
+const assertConfigFromMultiSecurityRequirementWithDefault: keyof O.Diff<Config10, ExpectedConfig10> extends never ? 1 : 0 = 1;
+assertConfigFromMultiSecurityRequirementWithDefault;

--- a/test/unit/StandardSdk.test.ts
+++ b/test/unit/StandardSdk.test.ts
@@ -60,7 +60,7 @@ describe('A StandardSDK', (): void => {
         },
       },
     });
-    await expect(ssdk.ticketmaster.SearchEvents()).resolves.toBe('response');
+    await expect(ssdk.ticketmaster.SearchEvents({}, { apiKey: 'abc123' })).resolves.toBe('response');
   });
 
   it('can access skl if sklEngineOptions are supplied.', (): void => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "resolveJsonModule": true,
     "module": "node16",
+    "noErrorTruncation": true
   },
   "include": [
     "src",


### PR DESCRIPTION
#### 📁 Related issues

Closes #20 and adds support for something similar to #21. Instead of the ability to add default headers, this makes it so that you can add a default config object to all operations related to an API spec.

#### ✍️ Description

- adds configuration param types 
- support for multiple security requirements
- adds default configuration per API Spec
